### PR TITLE
Change habit button label to "Mark Complete"

### DIFF
--- a/src/components/HabitCard.tsx
+++ b/src/components/HabitCard.tsx
@@ -164,7 +164,7 @@ const HabitCard: React.FC<HabitCardProps> = ({ habit, onHabitUpdate }) => {
                 className="w-full bg-green-600 hover:bg-green-700 text-white dark:bg-green-500 dark:hover:bg-green-600"
                 disabled={isCompletedToday}
               >
-                <CheckCircle2 className="mr-2 h-4 w-4" /> Mark Completed {isCompletedToday && "(Today)"}
+                <CheckCircle2 className="mr-2 h-4 w-4" /> Mark Complete {isCompletedToday && "(Today)"}
               </Button>
 
               <Dialog>


### PR DESCRIPTION
## Summary
- Rename HabitCard action button text from "Mark Completed" to "Mark Complete"

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype; and other lint errors)*
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68955870b6d48326aba7981def0a7b58