### PR TITLE
Fix achievement lock state comment

### DIFF
--- a/supabase/functions/generate-milestones/index.ts
+++ b/supabase/functions/generate-milestones/index.ts
@@ -143,7 +143,7 @@ Return only a JSON object with two keys: "milestones" (array of milestone object
         description: a.description,
         icon_name: iconName,
         trigger_condition: a.trigger_condition, // Store the trigger condition
-        is_unlocked: false, // Initially unlocked
+        is_unlocked: false, // Initially locked
         unlocked_at: null,
       };
     });


### PR DESCRIPTION
## Summary
- clarify that achievements start locked

## Testing
- `npm run lint` *(fails: Fast refresh warnings; no-explicit-any, prefer-const, no-require-imports errors)*

------
https://chatgpt.com/codex/tasks/task_e_68955897f67483268bfc6166076f7729