### PR TITLE
Add calculateEndDate tests using Node test runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --test"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",

--- a/src/lib/calculate-end-date.ts
+++ b/src/lib/calculate-end-date.ts
@@ -1,0 +1,23 @@
+import { addDays, addWeeks, addMonths, addYears, parseISO } from 'date-fns';
+
+export type DurationUnit = 'days' | 'weeks' | 'months' | 'years';
+
+// Calculate the end date for a habit given a start date and duration
+export const calculateEndDate = (
+  startDate: string,
+  value: number,
+  unit: DurationUnit,
+): Date => {
+  let date = parseISO(startDate);
+  switch (unit) {
+    case 'days':
+      return addDays(date, value);
+    case 'weeks':
+      return addWeeks(date, value);
+    case 'months':
+      return addMonths(date, value);
+    case 'years':
+      return addYears(date, value);
+  }
+};
+

--- a/src/lib/habit-store.test.ts
+++ b/src/lib/habit-store.test.ts
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { calculateEndDate } from './calculate-end-date.ts';
+
+test('calculateEndDate adds days correctly', () => {
+  const result = calculateEndDate('2023-01-01', 5, 'days');
+  assert.equal(result.toISOString().split('T')[0], '2023-01-06');
+});
+
+test('calculateEndDate adds weeks correctly', () => {
+  const result = calculateEndDate('2023-01-01', 2, 'weeks');
+  assert.equal(result.toISOString().split('T')[0], '2023-01-15');
+});
+
+test('calculateEndDate adds months correctly', () => {
+  const result = calculateEndDate('2023-01-01', 1, 'months');
+  assert.equal(result.toISOString().split('T')[0], '2023-02-01');
+});
+
+test('calculateEndDate adds years correctly', () => {
+  const result = calculateEndDate('2023-01-01', 1, 'years');
+  assert.equal(result.toISOString().split('T')[0], '2024-01-01');
+});

--- a/src/lib/habit-store.ts
+++ b/src/lib/habit-store.ts
@@ -1,6 +1,7 @@
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
-import { addDays, addWeeks, addMonths, addYears, isAfter, parseISO } from 'date-fns';
+import { isAfter } from 'date-fns';
+import { calculateEndDate } from './calculate-end-date.ts';
 
 export interface Milestone {
   goal: string; // e.g., "Walk 1000 steps"
@@ -107,25 +108,7 @@ export const deleteHabit = async (id: string): Promise<boolean> => {
   return true;
 };
 
-// Helper function to calculate end date for duration-based habits
-const calculateEndDate = (startDate: string, value: number, unit: 'days' | 'weeks' | 'months' | 'years'): Date => {
-  let date = parseISO(startDate);
-  switch (unit) {
-    case 'days':
-      date = addDays(date, value);
-      break;
-    case 'weeks':
-      date = addWeeks(date, value);
-      break;
-    case 'months':
-      date = addMonths(date, value);
-      break;
-    case 'years':
-      date = addYears(date, value);
-      break;
-  }
-  return date;
-};
+// calculateEndDate is imported from calculate-end-date.ts
 
 export const markHabitCompleted = async (habitId: string, userId: string): Promise<boolean> => {
   const { data: habits, error: fetchError } = await supabase


### PR DESCRIPTION
## Summary
- expose calculateEndDate via a standalone helper
- add tests verifying calculateEndDate handles days, weeks, months, and years
- add package script to run tests with Node's built-in runner

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689558a11cf883269579f1607cc193f7