### PR TITLE
Refresh habit completion state daily

### DIFF
--- a/src/components/HabitCard.tsx
+++ b/src/components/HabitCard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { CheckCircle2, Trash2, ListChecks, Repeat, Clock } from 'lucide-react'; // Import Repeat and Clock icons
@@ -79,7 +79,19 @@ const HabitCard: React.FC<HabitCardProps> = ({ habit, onHabitUpdate }) => {
   const firstUncompletedMilestoneIndex = habit.milestones.findIndex(m => !m.isCompleted);
   const currentMilestone = firstUncompletedMilestoneIndex !== -1 ? habit.milestones[firstUncompletedMilestoneIndex] : null;
 
-  const today = getLocalDateString();
+  const [today, setToday] = useState(getLocalDateString());
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setToday(prev => {
+        const current = getLocalDateString();
+        return current !== prev ? current : prev;
+      });
+    }, 60 * 1000);
+
+    return () => clearInterval(interval);
+  }, []);
+
   const isCompletedToday = habit.last_completed_date === today;
 
   const progressValue = currentMilestone


### PR DESCRIPTION
## Summary
- track today's date in HabitCard state
- refresh date each minute to reflect daily transitions
- derive daily completion status from the state date

## Testing
- `npm test`
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_689abd6003a48326ac1f6105a13f69cd