### PR TITLE
chore: switch goal page AI model

### DIFF
--- a/src/pages/AddHabitPage.tsx
+++ b/src/pages/AddHabitPage.tsx
@@ -245,14 +245,14 @@ const AddHabitPage: React.FC = () => {
             )}
           </div>
           <p className="text-xs text-gray-500 dark:text-gray-400 mt-6 text-center">
-            AI generation powered by CohereLabs/aya-expanse-8b:cohere, licensed under{' '}
+            AI generation powered by mistralai/Mistral-7B-Instruct-v0.2:featherless-ai, licensed under{' '}
             <a
-              href="https://creativecommons.org/licenses/by-nc-sa/4.0/"
+              href="https://www.apache.org/licenses/LICENSE-2.0"
               target="_blank"
               rel="noopener noreferrer"
               className="underline hover:text-gray-700 dark:hover:text-gray-300"
             >
-              CC BY-NC-SA 4.0
+              Apache 2.0
             </a>
             .
           </p>

--- a/supabase/functions/generate-milestones/index.ts
+++ b/supabase/functions/generate-milestones/index.ts
@@ -69,7 +69,7 @@ Return only a JSON object with two keys: "milestones" (array of milestone object
             content: promptContent,
           }
         ],
-        model: "CohereLabs/aya-expanse-8b:cohere",
+        model: "mistralai/Mistral-7B-Instruct-v0.2:featherless-ai",
         stream: false
       }),
     });


### PR DESCRIPTION
## Summary
- use `mistralai/Mistral-7B-Instruct-v0.2:featherless-ai` for milestone generation
- update Define Your Goal page footer to mention new model and license

## Testing
- `npm test`
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type, @typescript-eslint/no-explicit-any, prefer-const, @typescript-eslint/no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_689e94a2f260832681a6e83ad072f56a